### PR TITLE
Migrate codebase from PyQt5 to PyQt6

### DIFF
--- a/dcoraid/__main__.py
+++ b/dcoraid/__main__.py
@@ -10,14 +10,14 @@ def main(splash=True):
     setup_logging("dclab")
     setup_logging("requests", level=logging.INFO)
 
-    from PyQt5.QtWidgets import QApplication
+    from PyQt6.QtWidgets import QApplication
 
     if platform.win32_ver()[0] == "7":
         # Use software OpenGL on Windows 7, because sometimes the
         # window content becomes plain white.
         # Not sure whether this actually works.
-        from PyQt5.QtCore import Qt, QCoreApplication
-        from PyQt5.QtGui import QGuiApplication
+        from PyQt6.QtCore import Qt, QCoreApplication
+        from PyQt6.QtGui import QGuiApplication
         QApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
         QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
         QGuiApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
@@ -25,18 +25,18 @@ def main(splash=True):
     app = QApplication(sys.argv)
 
     if splash:
-        from PyQt5.QtWidgets import QSplashScreen
-        from PyQt5.QtGui import QPixmap
-        from PyQt5.QtCore import QEventLoop
+        from PyQt6.QtWidgets import QSplashScreen
+        from PyQt6.QtGui import QPixmap
+        from PyQt6.QtCore import QEventLoop
         ref_splash = resources.files("dcoraid.img") / "splash.png"
         with resources.as_file(ref_splash) as splash_path:
             splash_pix = QPixmap(str(splash_path))
         splash = QSplashScreen(splash_pix)
         splash.setMask(splash_pix.mask())
         splash.show()
-        app.processEvents(QEventLoop.AllEvents, 300)
+        app.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 300)
 
-    from PyQt5 import QtCore, QtGui
+    from PyQt6 import QtCore, QtGui
     from .gui import DCORAid
 
     # Set Application Icon
@@ -45,14 +45,14 @@ def main(splash=True):
         app.setWindowIcon(QtGui.QIcon(str(icon_path)))
 
     # Use dots as decimal separators
-    QtCore.QLocale.setDefault(QtCore.QLocale(QtCore.QLocale.C))
+    QtCore.QLocale.setDefault(QtCore.QLocale(QtCore.QLocale.Language.C))
 
     window = DCORAid()
 
     if splash:
         splash.finish(window)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/dcoraid/gui/api.py
+++ b/dcoraid/gui/api.py
@@ -5,7 +5,7 @@ import pathlib
 import shutil
 import tempfile
 
-from PyQt5 import QtCore
+from PyQt6 import QtCore
 
 from ..api import CKANAPI
 

--- a/dcoraid/gui/browse_public/widget_browse_public.py
+++ b/dcoraid/gui/browse_public/widget_browse_public.py
@@ -2,7 +2,7 @@ import traceback as tb
 
 from importlib import resources
 
-from PyQt5 import uic, QtCore, QtWidgets
+from PyQt6 import uic, QtCore, QtWidgets
 
 from ...common import ConnectionTimeoutErrors
 from ...dbmodel import APIInterrogator
@@ -29,7 +29,7 @@ class BrowsePublic(QtWidgets.QWidget):
 
     @QtCore.pyqtSlot()
     def on_public_search(self):
-        self.setCursor(QtCore.Qt.WaitCursor)
+        self.setCursor(QtCore.Qt.CursorShape.WaitCursor)
         api = get_ckan_api(
             public=not self.checkBox_public_include_private.isChecked())
         try:
@@ -44,7 +44,7 @@ class BrowsePublic(QtWidgets.QWidget):
                 self,
                 f"Failed to connect to {api.server}",
                 tb.format_exc(limit=1))
-        self.setCursor(QtCore.Qt.ArrowCursor)
+        self.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
 
     @staticmethod
     def find_main_window():

--- a/dcoraid/gui/dbview/drag_table_widget.py
+++ b/dcoraid/gui/dbview/drag_table_widget.py
@@ -1,5 +1,5 @@
-from PyQt5 import QtWidgets, QtCore, QtGui
-from PyQt5.QtCore import Qt
+from PyQt6 import QtWidgets, QtCore, QtGui
+from PyQt6.QtCore import Qt
 
 
 class DragTableWidget(QtWidgets.QTableWidget):
@@ -20,4 +20,4 @@ class DragTableWidget(QtWidgets.QTableWidget):
         drag.setHotSpot(e.pos() - self.rect().topLeft())
 
         # This magic is somehow required to get drag working.
-        dropAction = drag.exec_(Qt.CopyAction)  # noqa: F841
+        dropAction = drag.exec(Qt.CopyAction)  # noqa: F841

--- a/dcoraid/gui/dbview/filter_base.py
+++ b/dcoraid/gui/dbview/filter_base.py
@@ -1,7 +1,7 @@
 import copy
 from importlib import resources
 
-from PyQt5 import QtCore, QtGui, QtWidgets, uic
+from PyQt6 import QtCore, QtGui, QtWidgets, uic
 
 
 class FilterBase(QtWidgets.QWidget):
@@ -22,7 +22,8 @@ class FilterBase(QtWidgets.QWidget):
 
         # resize first column
         header = self.tableWidget.horizontalHeader()
-        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        header.setSectionResizeMode(0,
+                                    QtWidgets.QHeaderView.ResizeMode.Stretch)
 
         # trigger user selection change signal
         self.tableWidget.itemSelectionChanged.connect(self.on_entry_selected)
@@ -38,9 +39,10 @@ class FilterBase(QtWidgets.QWidget):
         self.tableWidget.setDragEnabled(False)  # disable drag
         self.tableWidget.setDragDropOverwriteMode(False)  # don't overwrite
         self.tableWidget.setDragDropMode(
-            QtWidgets.QAbstractItemView.NoDragDrop)  # drag & drop disabled
+            # drag & drop disabled
+            QtWidgets.QAbstractItemView.DragDropMode.NoDragDrop)
         self.tableWidget.setDefaultDropAction(
-            QtCore.Qt.IgnoreAction)  # no drop by default
+            QtCore.Qt.DropAction.IgnoreAction)  # no drop by default
 
     def get_entry_actions(self, row, entry):
         """This is defined in the subclasses (Circle, Collection, etc)"""

--- a/dcoraid/gui/dbview/filter_chain.py
+++ b/dcoraid/gui/dbview/filter_chain.py
@@ -2,7 +2,7 @@ import copy
 
 from importlib import resources
 
-from PyQt5 import QtCore, QtWidgets, uic
+from PyQt6 import QtCore, QtWidgets, uic
 
 from ..tools import ShowWaitCursor
 from ..api import get_ckan_api

--- a/dcoraid/gui/dbview/filter_views.py
+++ b/dcoraid/gui/dbview/filter_views.py
@@ -1,8 +1,8 @@
 from functools import partial
 import webbrowser
 
-from PyQt5 import QtCore, QtWidgets
-from PyQt5.QtCore import Qt
+from PyQt6 import QtCore, QtWidgets
+from PyQt6.QtCore import Qt
 
 from ..api import get_ckan_api
 from ..tools import ShowWaitCursor
@@ -64,7 +64,7 @@ class FilterCollections(filter_base.FilterBase):
                 for res_dict in ds_dict.get("resources", []):
                     self.download_resource.emit(res_dict["id"], condensed)
                     QtWidgets.QApplication.processEvents(
-                        QtCore.QEventLoop.AllEvents,
+                        QtCore.QEventLoop.ProcessEventsFlag.AllEvents,
                         300)
 
     def get_entry_actions(self, row, entry):
@@ -108,7 +108,7 @@ class FilterDatasets(filter_base.FilterBase):
         for res_dict in ds_dict.get("resources", []):
             self.download_resource.emit(res_dict["id"], condensed)
             QtWidgets.QApplication.processEvents(
-                QtCore.QEventLoop.AllEvents,
+                QtCore.QEventLoop.ProcessEventsFlag.AllEvents,
                 300)
 
     def get_entry_actions(self, row, entry):
@@ -139,7 +139,7 @@ class FilterResources(filter_base.FilterBase):
         self.checkBox.setChecked(True)
         self.tableWidget.setDragEnabled(True)
         self.tableWidget.setDragDropMode(
-            QtWidgets.QAbstractItemView.DragOnly)
+            QtWidgets.QAbstractItemView.DragDropMode.DragOnly)
         self.label_info.setText("<i>Tip: You can drag and drop your selection "
                                 "from the resources list to Shape-Out!</i>")
 

--- a/dcoraid/gui/download/widget_download.py
+++ b/dcoraid/gui/download/widget_download.py
@@ -9,8 +9,8 @@ import platform
 import subprocess
 import webbrowser
 
-from PyQt5 import uic, QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import QStandardPaths
+from PyQt6 import uic, QtCore, QtGui, QtWidgets
+from PyQt6.QtCore import QStandardPaths
 
 from ...download import DownloadQueue
 
@@ -37,7 +37,7 @@ class DownloadWidget(QtWidgets.QWidget):
         #: path to persistent shelf to be able to resume uploads on startup
         self.shelf_path = os_path.join(
             QStandardPaths.writableLocation(
-                QStandardPaths.AppLocalDataLocation),
+                QStandardPaths.StandardLocation.AppLocalDataLocation),
             "persistent_download_jobs")
 
         #: DownloadQueue instance
@@ -85,7 +85,7 @@ class DownloadWidget(QtWidgets.QWidget):
     @QtCore.pyqtSlot(str, bool)
     def download_resource(self, resource_id, condensed=False):
         fallback = QStandardPaths.writableLocation(
-                      QStandardPaths.DownloadLocation)
+                      QStandardPaths.StandardLocation.DownloadLocation)
         dl_path = self.settings.value("downloads/default path", fallback)
         self.widget_jobs.jobs.new_job(resource_id, dl_path, condensed)
 
@@ -182,14 +182,14 @@ class DownloadTableWidget(QtWidgets.QTableWidget):
                 job.traceback = traceback.format_exc()
 
             QtWidgets.QApplication.processEvents(
-                QtCore.QEventLoop.AllEvents,
-                300)
+                QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
 
         # spacing (did not work in __init__)
         header = self.horizontalHeader()
         header.setSectionResizeMode(
-            0, QtWidgets.QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+            0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(
+            1, QtWidgets.QHeaderView.ResizeMode.Stretch)
 
         self._busy_updating_widgets = False
 

--- a/dcoraid/gui/logs/widget_log.py
+++ b/dcoraid/gui/logs/widget_log.py
@@ -9,7 +9,7 @@ import sys
 import time
 import traceback
 
-from PyQt5 import uic, QtCore, QtWidgets
+from PyQt6 import uic, QtCore, QtWidgets
 
 from ..._version import version
 

--- a/dcoraid/gui/main.py
+++ b/dcoraid/gui/main.py
@@ -12,7 +12,7 @@ import requests_cache
 import requests_toolbelt
 import urllib3
 
-from PyQt5 import uic, QtCore, QtGui, QtWidgets
+from PyQt6 import uic, QtCore, QtGui, QtWidgets
 
 from ..api import APIOutdatedError
 from ..common import ConnectionTimeoutErrors
@@ -57,20 +57,19 @@ class DCORAid(QtWidgets.QMainWindow):
         QtCore.QCoreApplication.setOrganizationName("DCOR")
         QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
         QtCore.QCoreApplication.setApplicationName("dcoraid")
-        QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+        QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
 
         super(DCORAid, self).__init__(*args, **kwargs)
 
         # if "--version" was specified, print the version and exit
         if "--version" in sys.argv:
             print(__version__)
-            QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents,
-                                                 300)
+            QtWidgets.QApplication.processEvents(
+                QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
             sys.exit(0)
 
         #: DCOR-Aid settings
         self.settings = QtCore.QSettings()
-        self.settings.setIniCodec("utf-8")
         ref_ui = resources.files("dcoraid.gui") / "main.ui"
         with resources.as_file(ref_ui) as path_ui:
             uic.loadUi(path_ui, self)
@@ -111,8 +110,8 @@ class DCORAid(QtWidgets.QMainWindow):
         self.user_filter_chain.download_resource.connect(
             self.panel_download.download_resource)
 
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents,
-                                             300)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
 
         # Run wizard if necessary
         if ((self.settings.value("user scenario", "") != "anonymous")
@@ -137,8 +136,8 @@ class DCORAid(QtWidgets.QMainWindow):
         self.panel_upload.prepare_quit()
         self.panel_download.prepare_quit()
         self.status_widget.prepare_quit()
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents,
-                                             300)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
         event.accept()
 
     @QtCore.pyqtSlot()
@@ -214,7 +213,7 @@ class DCORAid(QtWidgets.QMainWindow):
         sw_text += "Modules:\n"
         for lib in libs:
             sw_text += "- {} {}\n".format(lib.__name__, lib.__version__)
-        sw_text += "- PyQt5 {}\n".format(QtCore.QT_VERSION_STR)
+        sw_text += "- PyQt6 {}\n".format(QtCore.QT_VERSION_STR)
         sw_text += "\n Breeze icon theme by the KDE Community (LGPL)."
         sw_text += "\n Font-Awesome icons by Fort Awesome (CC BY 4.0)."
         if hasattr(sys, 'frozen'):
@@ -225,7 +224,7 @@ class DCORAid(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot()
     def on_refresh_private_data(self):
-        self.tab_user.setCursor(QtCore.Qt.WaitCursor)
+        self.tab_user.setCursor(QtCore.Qt.CursorShape.WaitCursor)
         api = get_ckan_api()
         data = DBExtract()
         if api.is_available() and api.api_key:
@@ -244,12 +243,12 @@ class DCORAid(QtWidgets.QMainWindow):
                     self,
                     f"Failed to connect to {api.server}",
                     tb.format_exc(limit=1))
-        self.tab_user.setCursor(QtCore.Qt.ArrowCursor)
+        self.tab_user.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
 
     @QtCore.pyqtSlot()
     def on_wizard(self):
         self.wizard = SetupWizard(self)
-        self.wizard.exec_()
+        self.wizard.exec()
 
 
 def excepthook(etype, value, trace):
@@ -283,13 +282,13 @@ def excepthook(etype, value, trace):
         )
 
     errorbox = QtWidgets.QMessageBox()
-    errorbox.setIcon(QtWidgets.QMessageBox.Critical)
+    errorbox.setIcon(QtWidgets.QMessageBox.Icon.Critical)
     errorbox.addButton(QtWidgets.QPushButton('Close'),
-                       QtWidgets.QMessageBox.YesRole)
+                       QtWidgets.QMessageBox.ButtonRole.YesRole)
     errorbox.addButton(QtWidgets.QPushButton(
-        'Copy text && Close'), QtWidgets.QMessageBox.NoRole)
+        'Copy text && Close'), QtWidgets.QMessageBox.ButtonRole.NoRole)
     errorbox.setText(exception)
-    ret = errorbox.exec_()
+    ret = errorbox.exec()
     if ret == 1:
         cb = QtWidgets.QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)

--- a/dcoraid/gui/maintenance/widget_maintenance.py
+++ b/dcoraid/gui/maintenance/widget_maintenance.py
@@ -3,8 +3,8 @@ import shutil
 
 from importlib import resources
 
-from PyQt5 import uic, QtCore, QtWidgets
-from PyQt5.QtCore import QStandardPaths
+from PyQt6 import uic, QtCore, QtWidgets
+from PyQt6.QtCore import QStandardPaths
 
 from ...api import dataset_draft_remove_all
 from ...upload import PersistentUploadJobList
@@ -43,7 +43,7 @@ class MaintenanceWidget(QtWidgets.QWidget):
         queue = mw.panel_upload.jobs
         dirs = queue.find_zombie_caches()
         msg = QtWidgets.QMessageBox()
-        msg.setIcon(QtWidgets.QMessageBox.Information)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
         if dirs:
             [shutil.rmtree(pp, ignore_errors=True) for pp in dirs]
             details = [f"- {pp}" for pp in dirs]
@@ -53,7 +53,7 @@ class MaintenanceWidget(QtWidgets.QWidget):
         else:
             msg.setText("No zombie cache data found.")
             msg.setWindowTitle("Nothing to do")
-        msg.exec_()
+        msg.exec()
 
     @QtCore.pyqtSlot()
     def on_remove_drafts(self):
@@ -61,7 +61,7 @@ class MaintenanceWidget(QtWidgets.QWidget):
             # get all dataset IDs that should not be removed
             pers_job_path = os_path.join(
                 QStandardPaths.writableLocation(
-                    QStandardPaths.AppLocalDataLocation),
+                    QStandardPaths.StandardLocation.AppLocalDataLocation),
                 "persistent_upload_jobs")
             pers_datasets = PersistentUploadJobList(pers_job_path)
             # perform deletion
@@ -69,7 +69,7 @@ class MaintenanceWidget(QtWidgets.QWidget):
                 api=get_ckan_api(),
                 ignore_dataset_ids=pers_datasets)
         msg = QtWidgets.QMessageBox()
-        msg.setIcon(QtWidgets.QMessageBox.Information)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
         del_titles = [f"{d['name']}" for d in deleted]
         ign_titles = [f"{d['name']}" for d in ignored]
         if del_titles + ign_titles:
@@ -83,4 +83,4 @@ class MaintenanceWidget(QtWidgets.QWidget):
         else:
             msg.setText("No drafts found.")
             msg.setWindowTitle("Nothing to do")
-        msg.exec_()
+        msg.exec()

--- a/dcoraid/gui/preferences/dlg_preferences.py
+++ b/dcoraid/gui/preferences/dlg_preferences.py
@@ -6,8 +6,9 @@ import socket
 import string
 import traceback as tb
 
-from PyQt5 import uic, QtCore, QtWidgets
-from PyQt5.QtCore import QStandardPaths
+from PyQt6 import uic, QtCore, QtWidgets
+from PyQt6.QtCore import QStandardPaths
+from PyQt6.QtWidgets import QMessageBox
 
 from ...api import NoAPIKeyError, CKANAPI
 from ...common import ConnectionTimeoutErrors
@@ -66,16 +67,16 @@ class PreferencesDialog(QtWidgets.QMainWindow):
 
         ...because it implies a restart of DCOR-Aid.
         """
-        button_reply = QtWidgets.QMessageBox.question(
+        button_reply = QMessageBox.question(
             self,
             'DCOR-Aid restart required',
             "Changing the server or API token requires a restart of "
             + "DCOR-Aid. If you choose 'No', then the original server "
             + "and API token are NOT changed. Do you really want to quit "
             + "DCOR-Aid?",
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-            QtWidgets.QMessageBox.No)
-        if button_reply == QtWidgets.QMessageBox.Yes:
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No)
+        if button_reply == QMessageBox.StandardButton.Yes:
             return True
         else:
             return False
@@ -83,10 +84,10 @@ class PreferencesDialog(QtWidgets.QMainWindow):
     @QtCore.pyqtSlot()
     def on_toggle_api_password_view(self):
         cur_em = self.lineEdit_api_key.echoMode()
-        if cur_em == QtWidgets.QLineEdit.Normal:
-            new_em = QtWidgets.QLineEdit.PasswordEchoOnEdit
+        if cur_em == QtWidgets.QLineEdit.EchoMode.Normal:
+            new_em = QtWidgets.QLineEdit.EchoMode.PasswordEchoOnEdit
         else:
-            new_em = QtWidgets.QLineEdit.Normal
+            new_em = QtWidgets.QLineEdit.EchoMode.Normal
         self.lineEdit_api_key.setEchoMode(new_em)
 
     @QtCore.pyqtSlot()
@@ -95,7 +96,7 @@ class PreferencesDialog(QtWidgets.QMainWindow):
             api_key = self.settings.value("auth/api key")
             if len(api_key) == 36:
                 # deprecated API key
-                ret = QtWidgets.QMessageBox.question(
+                ret = QMessageBox.question(
                     self,
                     "Deprecated API key",
                     "You are using an API key instead of an API token. "
@@ -103,7 +104,7 @@ class PreferencesDialog(QtWidgets.QMainWindow):
                     + "DCOR-Aid can only remove it locally. A new API token "
                     + "will be created. Proceed?"
                 )
-                if ret != QtWidgets.QMessageBox.Yes:
+                if ret != QMessageBox.StandardButton.Yes:
                     # Abort
                     return
             # Create a new token
@@ -132,14 +133,14 @@ class PreferencesDialog(QtWidgets.QMainWindow):
             api_key = self.settings.value("auth/api key")
             if len(api_key) == 36:
                 # deprecated API key
-                ret = QtWidgets.QMessageBox.question(
+                ret = QMessageBox.question(
                     self,
                     "Deprecated API key",
                     "You are using an API key instead of an API token. "
                     + "API keys are deprecated and cannot be invalidated. "
                     + "DCOR-Aid can only remove it locally. Proceed?"
                 )
-                if ret != QtWidgets.QMessageBox.Yes:
+                if ret != QMessageBox.StandardButton.Yes:
                     # Abort
                     return
             else:
@@ -167,7 +168,7 @@ class PreferencesDialog(QtWidgets.QMainWindow):
 
     def on_downloads_init(self):
         fallback = QStandardPaths.writableLocation(
-                      QStandardPaths.DownloadLocation)
+                      QStandardPaths.StandardLocation.DownloadLocation)
         dl_path = self.settings.value("downloads/default path", fallback)
         self.lineEdit_downloads_path.setText(dl_path)
 
@@ -180,12 +181,12 @@ class PreferencesDialog(QtWidgets.QMainWindow):
         path_cache = self.lineEdit_uploads_cache.text()
         self.settings.setValue("uploads/cache path", path_cache)
         if path_cache != current:
-            msg = QtWidgets.QMessageBox()
-            msg.setIcon(QtWidgets.QMessageBox.Warning)
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
             msg.setText("In order for the new cache path to be used, please "
                         "restart DCOR-Aid!")
             msg.setWindowTitle("Please restart DCOR-Aid")
-            msg.exec_()
+            msg.exec()
 
     def on_uploads_browse(self):
         default = self.settings.value("uploads/cache path", ".")
@@ -199,7 +200,7 @@ class PreferencesDialog(QtWidgets.QMainWindow):
     @QtCore.pyqtSlot()
     def on_uploads_init(self):
         fallback = QStandardPaths.writableLocation(
-                      QStandardPaths.CacheLocation)
+                      QStandardPaths.StandardLocation.CacheLocation)
         cache_path = self.settings.value("uploads/cache path", fallback)
         if not pathlib.Path(cache_path).exists():
             cache_path = fallback
@@ -225,7 +226,7 @@ class PreferencesDialog(QtWidgets.QMainWindow):
         self.lineEdit_api_key.setText(self.settings.value("auth/api key", ""))
         self.tabWidget.setCurrentIndex(0)  # server settings
         self.lineEdit_api_key.setEchoMode(
-            QtWidgets.QLineEdit.PasswordEchoOnEdit)
+            QtWidgets.QLineEdit.EchoMode.PasswordEchoOnEdit)
         self.show()
         self.activateWindow()
 
@@ -237,12 +238,12 @@ class PreferencesDialog(QtWidgets.QMainWindow):
             user_dict = api.get_user_dict()
         except tuple(list(ConnectionTimeoutErrors) + [NoAPIKeyError]):
             self.logger.error(tb.format_exc())
-            msg = QtWidgets.QMessageBox()
-            msg.setIcon(QtWidgets.QMessageBox.Warning)
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
             msg.setText("No connection or wrong server or invalid API token!")
             msg.setWindowTitle("Warning")
             msg.setDetailedText(tb.format_exc())
-            msg.exec_()
+            msg.exec()
             self.on_show_server()
         else:
             self.lineEdit_user_id.setText(user_dict["name"])
@@ -268,12 +269,12 @@ class PreferencesDialog(QtWidgets.QMainWindow):
             user_dict = api.get_user_dict()
         except (ConnectionError, NoAPIKeyError):
             self.logger.error(tb.format_exc())
-            msg = QtWidgets.QMessageBox()
-            msg.setIcon(QtWidgets.QMessageBox.Warning)
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
             msg.setText("No connection or wrong server or invalid API token!")
             msg.setWindowTitle("Warning")
             msg.setDetailedText(tb.format_exc())
-            msg.exec_()
+            msg.exec()
             self.on_show_server()
         update_dict = {}
         update_dict["id"] = user_dict["id"]
@@ -307,12 +308,12 @@ class PreferencesDialog(QtWidgets.QMainWindow):
             api.get_user_dict()  # raises an exception if credentials are wrong
         except BaseException:
             self.logger.error(tb.format_exc())
-            msg = QtWidgets.QMessageBox()
-            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Icon.Critical)
             msg.setText("Bad server / API token combination!")
             msg.setWindowTitle("Error")
             msg.setDetailedText(tb.format_exc())
-            msg.exec_()
+            msg.exec()
         else:
             if old_server != server or old_api_key != api_key:
                 if self.ask_change_server_or_api_key():

--- a/dcoraid/gui/status_widget.py
+++ b/dcoraid/gui/status_widget.py
@@ -3,7 +3,7 @@ import pathlib
 import requests
 import traceback
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from ..common import ConnectionTimeoutErrors
 
@@ -26,7 +26,7 @@ class StatusWidget(QtWidgets.QWidget):
         self.toolButton_user = QtWidgets.QToolButton()
         self.toolButton_user.setText("Initialization...")
         self.toolButton_user.setToolButtonStyle(
-            QtCore.Qt.ToolButtonTextBesideIcon)
+            QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.toolButton_user.setAutoRaise(True)
         self.layout.addWidget(self.toolButton_user)
         self.toolButton_user.clicked.connect(self.clicked)
@@ -56,7 +56,8 @@ class StatusWidget(QtWidgets.QWidget):
     def get_favicon(server):
         dldir = pathlib.Path(
             QtCore.QStandardPaths.writableLocation(
-                QtCore.QStandardPaths.AppDataLocation)) / "favicons"
+                QtCore.QStandardPaths.StandardLocation.AppDataLocation)
+            ) / "favicons"
 
         dldir.mkdir(exist_ok=True, parents=True)
         favname = dldir / (server.split("://")[1] + "_favicon.ico")

--- a/dcoraid/gui/tools/wait_cursor.py
+++ b/dcoraid/gui/tools/wait_cursor.py
@@ -1,16 +1,16 @@
 import functools
 
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtGui import QCursor
-from PyQt5.QtCore import Qt, QEventLoop
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtGui import QCursor
+from PyQt6.QtCore import Qt, QEventLoop
 
 
 class ShowWaitCursor:
     def __enter__(self):
-        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         # This overloaded function call makes sure that all events,
         # even those triggered during the function call, are processed.
-        QApplication.processEvents(QEventLoop.AllEvents, 50)
+        QApplication.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 50)
         return self
 
     def __exit__(self, type, value, traceback):

--- a/dcoraid/gui/updater.py
+++ b/dcoraid/gui/updater.py
@@ -6,7 +6,7 @@ import traceback
 import urllib.request
 
 from dclab.external.packaging import parse as parse_version
-from PyQt5 import QtCore
+from PyQt6 import QtCore
 
 
 class UpdateWorker(QtCore.QObject):

--- a/dcoraid/gui/upload/circle_mgr.py
+++ b/dcoraid/gui/upload/circle_mgr.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from PyQt5 import QtWidgets
+from PyQt6 import QtWidgets
 
 from ..api import get_ckan_api
 
@@ -40,7 +40,7 @@ def ask_for_new_circle(parent_widget):
         + "a colleague to add you to a Circle (Your user name is "
         + "'{}').".format(ud["name"])
         + "\n\nTo proceed with Circle creation, please choose a name:",
-        QtWidgets.QLineEdit.Normal,
+        QtWidgets.QLineEdit.EchoMode.Normal,
         "{}'s Circle".format(name))
     if ok_pressed and text != '':
         cname = "user-circle-{}".format(ud["name"])

--- a/dcoraid/gui/upload/dlg_upload.py
+++ b/dcoraid/gui/upload/dlg_upload.py
@@ -3,7 +3,7 @@ import pathlib
 from importlib import resources
 import traceback as tb
 
-from PyQt5 import uic, QtCore, QtGui, QtWidgets
+from PyQt6 import uic, QtCore, QtGui, QtWidgets
 
 
 from ...api import dataset_create
@@ -38,10 +38,10 @@ class UploadDialog(QtWidgets.QDialog):
 
         # Dialog box buttons
         self.pushButton_proceed = self.buttonBox.button(
-            QtWidgets.QDialogButtonBox.Apply)
+            QtWidgets.QDialogButtonBox.StandardButton.Apply)
         self.pushButton_proceed.setText("Proceed with upload / Enqueue job")
         self.pushButton_cancel = self.buttonBox.button(
-            QtWidgets.QDialogButtonBox.Cancel)
+            QtWidgets.QDialogButtonBox.StandardButton.Cancel)
 
         # Keep identifier
         self.identifier = self.instance_counter
@@ -322,7 +322,7 @@ class UploadDialog(QtWidgets.QDialog):
                 + "Please select 'No' if you would like to change things. "
                 + "Select 'Yes' to proceed without changes - be aware that "
                 + "you will not be able to change anything later on.")
-            if choice != QtWidgets.QMessageBox.Yes:
+            if choice != QtWidgets.QMessageBox.StandardButton.Yes:
                 return
         if not self.rvmodel.supplements_were_edited():
             choice = QtWidgets.QMessageBox.question(
@@ -333,7 +333,7 @@ class UploadDialog(QtWidgets.QDialog):
                 + "appear when you click on a resource. Please select 'No' "
                 + "if you would like to go back (recommended). Select 'Yes' "
                 + "to proceed without changes (no future changes possible).")
-            if choice != QtWidgets.QMessageBox.Yes:
+            if choice != QtWidgets.QMessageBox.StandardButton.Yes:
                 return
 
         # Try to create the dataset and display any issues with the metadata
@@ -343,7 +343,7 @@ class UploadDialog(QtWidgets.QDialog):
         except BaseException:
             self.logger.error(tb.format_exc())
             msg = QtWidgets.QMessageBox()
-            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
             msg.setText("It was not possible to create a dataset draft. "
                         "If this is not a connection problem, please consider "
                         "creating an <a href='"
@@ -351,7 +351,7 @@ class UploadDialog(QtWidgets.QDialog):
                         "'>issue on GitHub</a>.")
             msg.setWindowTitle("Dataset creation failed")
             msg.setDetailedText(tb.format_exc())
-            msg.exec_()
+            msg.exec()
             return
         self.setHidden(True)
         # Remember the dataset identifier

--- a/dcoraid/gui/upload/resource_schema_preset.py
+++ b/dcoraid/gui/upload/resource_schema_preset.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 
-from PyQt5.QtCore import QStandardPaths
+from PyQt6.QtCore import QStandardPaths
 
 
 class PersistentResourceSchemaPresets:
@@ -10,7 +10,8 @@ class PersistentResourceSchemaPresets:
         self._presets = {}
         # This is a roaming path on Windows
         self.path = pathlib.Path(QStandardPaths.writableLocation(
-            QStandardPaths.AppDataLocation)) / "upload_resource_schema_presets"
+            QStandardPaths.StandardLocation.AppDataLocation)
+            ) / "upload_resource_schema_presets"
         self.path.mkdir(exist_ok=True, parents=True)
         for pp in self.path.glob("*.json"):
             with pp.open() as fd:

--- a/dcoraid/gui/upload/resources_model.py
+++ b/dcoraid/gui/upload/resources_model.py
@@ -4,7 +4,7 @@ import copy
 from functools import lru_cache
 import pathlib
 
-from PyQt5 import QtCore, QtGui
+from PyQt6 import QtCore, QtGui
 
 from ...upload import job
 
@@ -31,9 +31,9 @@ class ResourcesModel(QtCore.QAbstractListModel):
                 self.resources[ff] = {}
                 self.layoutChanged.emit()
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole):
         """Return data for 'View'"""
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
             _, data = self.get_data_for_index(index)
             return data["file"]["filename"]
 

--- a/dcoraid/gui/upload/widget_schema.py
+++ b/dcoraid/gui/upload/widget_schema.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 from .widget_supplement_item import RSSItem, RSSTagsItem, TitleItem
 

--- a/dcoraid/gui/upload/widget_supplement_item.py
+++ b/dcoraid/gui/upload/widget_supplement_item.py
@@ -1,6 +1,6 @@
 from importlib import resources
 
-from PyQt5 import uic, QtCore, QtWidgets
+from PyQt6 import uic, QtCore, QtWidgets
 
 
 class TitleItem(QtWidgets.QWidget):

--- a/dcoraid/gui/upload/widget_tablecell_actions.py
+++ b/dcoraid/gui/upload/widget_tablecell_actions.py
@@ -1,7 +1,7 @@
 from importlib import resources
 import webbrowser
 
-from PyQt5 import uic, QtCore, QtWidgets
+from PyQt6 import uic, QtCore, QtWidgets
 
 
 class TableCellActions(QtWidgets.QWidget):
@@ -38,7 +38,7 @@ class TableCellActions(QtWidgets.QWidget):
     @QtCore.pyqtSlot()
     def on_error(self):
         msg = QtWidgets.QMessageBox()
-        msg.setIcon(QtWidgets.QMessageBox.Critical)
+        msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
         msg.setText("There was an error during data transfer. If this happens "
                     + "often or with a particular type of dataset, please "
                     + "<a href='https://github.com/DCOR-dev/DCOR-Aid/issues'>"
@@ -46,7 +46,7 @@ class TableCellActions(QtWidgets.QWidget):
                       "to see details required for fixing the problem.")
         msg.setWindowTitle(f"Job {self.job.dataset_id[:5]} error")
         msg.setDetailedText(self.job.traceback)
-        msg.exec_()
+        msg.exec()
 
     @QtCore.pyqtSlot()
     def on_retry(self):

--- a/dcoraid/gui/wizard/__init__.py
+++ b/dcoraid/gui/wizard/__init__.py
@@ -3,7 +3,8 @@ import sys
 import uuid
 
 from dclab.rtdc_dataset.fmt_dcor import access_token
-from PyQt5 import uic, QtCore, QtWidgets
+from PyQt6 import uic, QtCore, QtWidgets
+from PyQt6.QtWidgets import QMessageBox, QWizard
 
 from ...api import NoAPIKeyError, APINotFoundError, CKANAPI
 
@@ -73,7 +74,7 @@ class SetupWizard(QtWidgets.QWizard):
 
         self.pushButton_path_access_token.clicked.connect(
             self.on_browse_access_token)
-        self.button(QtWidgets.QWizard.FinishButton).clicked.connect(
+        self.button(QWizard.WizardButton.FinishButton).clicked.connect(
             self._finalize)
 
     @QtCore.pyqtSlot()
@@ -94,18 +95,19 @@ class SetupWizard(QtWidgets.QWizard):
                       + "of DCOR-Aid. If you choose 'No', then the original " \
                       + "server and API token are NOT changed. Do you " \
                       + "really want to quit DCOR-Aid?"
-                button_reply = QtWidgets.QMessageBox.question(
+                button_reply = QMessageBox.question(
                     self,
                     'DCOR-Aid restart required',
                     msg,
-                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                    QtWidgets.QMessageBox.No)
-                if button_reply == QtWidgets.QMessageBox.Yes:
+                    QMessageBox.StandardButton.Yes |
+                    QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No)
+                if button_reply == QMessageBox.StandardButton.Yes:
                     proceed = True
                 else:
                     proceed = False
             else:
-                QtWidgets.QMessageBox.information(
+                QMessageBox.information(
                     self,
                     "DCOR-Aid restart required",
                     "Please restart DCOR-Aid to proceed."
@@ -127,7 +129,7 @@ class SetupWizard(QtWidgets.QWizard):
                     settings.remove("auth/certificate")
                 settings.sync()
                 QtWidgets.QApplication.processEvents(
-                    QtCore.QEventLoop.AllEvents, 300)
+                    QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
                 QtWidgets.QApplication.quit()
                 sys.exit(0)  # if the above does not work
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-GUI = ["pyqt5"]
+GUI = ["PyQt6"]
 
 [project.scripts]
 dcoraid = "dcoraid.__main__:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import shutil
 import tempfile
 import time
 
-from PyQt5 import QtCore
-from PyQt5.QtCore import QStandardPaths
+from PyQt6 import QtCore
+from PyQt6.QtCore import QStandardPaths
 import pytest
 
 from dcoraid.api import APIConflictError
@@ -28,13 +28,13 @@ def cleanup_dcoraid_tasks():
     # remove persistent upload jobs
     shelf_path = os_path.join(
         QStandardPaths.writableLocation(
-            QStandardPaths.AppLocalDataLocation),
+            QStandardPaths.StandardLocation.AppLocalDataLocation),
         "persistent_upload_jobs")
     shutil.rmtree(shelf_path, ignore_errors=True)
     # remove persistent upload id dict
     path_id_dict = os_path.join(
         QStandardPaths.writableLocation(
-            QStandardPaths.AppLocalDataLocation),
+            QStandardPaths.StandardLocation.AppLocalDataLocation),
         "map_task_to_dataset_id.txt")
     path_id_dict = pathlib.Path(path_id_dict)
     if path_id_dict.exists():
@@ -47,9 +47,8 @@ def pytest_configure(config):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
-    settings.setIniCodec("utf-8")
     settings.setValue("check for updates", "0")
     settings.setValue("user scenario", "dcor-dev")
     settings.setValue("auth/server", "dcor-dev.mpl.mpg.de")
@@ -70,9 +69,8 @@ def pytest_unconfigure(config):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
-    settings.setIniCodec("utf-8")
     settings.remove("debug/without timers")
     settings.remove("check for updates")
     settings.sync()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pyqt5
+PyQt6
 pytest
 pytest-qt
 pluggy>=1.0

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -11,8 +11,8 @@ from dcoraid.gui.upload.dlg_upload import UploadDialog
 from dcoraid.gui.upload import widget_upload
 
 import pytest
-from PyQt5 import QtCore, QtWidgets, QtTest
-from PyQt5.QtWidgets import QInputDialog, QMessageBox
+from PyQt6 import QtCore, QtGui, QtWidgets, QtTest
+from PyQt6.QtWidgets import QInputDialog, QMessageBox
 
 from . import common
 
@@ -24,25 +24,27 @@ def mw(qtbot):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
-    settings.setIniCodec("utf-8")
     settings.setValue("auth/server", "dcor-dev.mpl.mpg.de")
     QtTest.QTest.qWait(100)
-    QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+    QtWidgets.QApplication.processEvents(
+        QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
     # Code that will run before your test
     mw = DCORAid()
     qtbot.addWidget(mw)
     QtWidgets.QApplication.setActiveWindow(mw)
     QtTest.QTest.qWait(100)
-    QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+    QtWidgets.QApplication.processEvents(
+        QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
     # Run test
     yield mw
     # Make sure that all daemons are gone
     mw.close()
     # It is extremely weird, but this seems to be important to avoid segfaults!
     QtTest.QTest.qWait(100)
-    QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+    QtWidgets.QApplication.processEvents(
+        QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning",
@@ -52,7 +54,7 @@ def test_gui_anonymous(qtbot):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
     spath = pathlib.Path(settings.fileName())
     # temporarily move settings to temporary location
@@ -73,7 +75,8 @@ def test_gui_anonymous(qtbot):
         mw = DCORAid()
         qtbot.addWidget(mw)
         QtWidgets.QApplication.setActiveWindow(mw)
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 3000)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 3000)
         # sanity check
         assert mw.settings.value("user scenario") == "anonymous"
         assert mw.settings.value("auth/server") == "dcor.mpl.mpg.de"
@@ -87,7 +90,8 @@ def test_gui_anonymous(qtbot):
         shutil.copy2(stmp, spath)
     mw.close()
     QtTest.QTest.qWait(500)
-    QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 500)
+    QtWidgets.QApplication.processEvents(
+        QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 500)
 
 
 def test_gui_mydata_dataset_add_to_collection(mw, qtbot):
@@ -144,22 +148,23 @@ def test_gui_start_with_bad_server(qtbot):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
-    settings.setIniCodec("utf-8")
     settings.setValue("auth/server", "WRONG-dcor-dev.mpl.mpg.de")
     try:
         mw = DCORAid()
         qtbot.addWidget(mw)
         QtWidgets.QApplication.setActiveWindow(mw)
         QtTest.QTest.qWait(200)
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
         # just make sure that DCOR-Aid thinks it is offline
         assert not mw.panel_upload.isEnabled()
         assert not mw.panel_download.isEnabled()
         mw.close()
         QtTest.QTest.qWait(500)
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
     except BaseException:
         raise
     finally:
@@ -171,9 +176,8 @@ def test_gui_start_with_bad_api_key(qtbot):
     QtCore.QCoreApplication.setOrganizationName("DCOR")
     QtCore.QCoreApplication.setOrganizationDomain("dcor.mpl.mpg.de")
     QtCore.QCoreApplication.setApplicationName("dcoraid")
-    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.Format.IniFormat)
     settings = QtCore.QSettings()
-    settings.setIniCodec("utf-8")
     good_key = settings.value("auth/api key")
     bad_key = good_key[:-2] + "00"
     settings.setValue("auth/api key", bad_key)
@@ -182,14 +186,16 @@ def test_gui_start_with_bad_api_key(qtbot):
         qtbot.addWidget(mw)
         QtWidgets.QApplication.setActiveWindow(mw)
         QtTest.QTest.qWait(200)
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
         # just make sure that DCOR-Aid thinks it is offline
         assert not mw.panel_upload.isEnabled()
         # downloads should still be possible
         assert mw.panel_download.isEnabled()
         mw.close()
         QtTest.QTest.qWait(500)
-        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 5000)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 5000)
     except BaseException:
         raise
     finally:
@@ -207,7 +213,7 @@ def test_gui_upload_simple(mw, qtbot):
     # Avoid message boxes
     with mock.patch.object(QMessageBox,
                            "question",
-                           return_value=QMessageBox.Yes):
+                           return_value=QMessageBox.StandardButton.Yes):
         # Commence upload
         dlg.on_proceed()
     assert dlg.dataset_id is not None
@@ -223,7 +229,7 @@ def test_gui_upload_task(mw, qtbot):
                            return_value=([tpath], None)):
         with mock.patch.object(QMessageBox, "information",
                                return_value=None):
-            act = QtWidgets.QAction("some unimportant text")
+            act = QtGui.QAction("some unimportant text")
             act.setData("single")
             mw.panel_upload.on_upload_task(action=act)
     uj = mw.panel_upload.jobs[-1]
@@ -242,9 +248,9 @@ def test_gui_upload_task_bad_dataset_id_no(mw, qtbot):
             QtWidgets.QFileDialog, "getOpenFileNames",
             return_value=([tpath], None)), \
          mock.patch.object(QMessageBox, "question",
-                           return_value=QMessageBox.No), \
+                           return_value=QMessageBox.StandardButton.No), \
          mock.patch.object(QMessageBox, "information", return_value=None):
-        act = QtWidgets.QAction("some unimportant text")
+        act = QtGui.QAction("some unimportant text")
         act.setData("single")
         mw.panel_upload.on_upload_task(action=act)
     if len(mw.panel_upload.jobs):
@@ -263,9 +269,9 @@ def test_gui_upload_task_bad_dataset_id_yes(mw, qtbot):
             QtWidgets.QFileDialog, "getOpenFileNames",
             return_value=([tpath], None)), \
          mock.patch.object(QMessageBox, "question",
-                           return_value=QMessageBox.Yes), \
+                           return_value=QMessageBox.StandardButton.Yes), \
          mock.patch.object(QMessageBox, "information", return_value=None):
-        act = QtWidgets.QAction("some unimportant text")
+        act = QtGui.QAction("some unimportant text")
         act.setData("single")
         mw.panel_upload.on_upload_task(action=act)
     uj = mw.panel_upload.jobs[-1]
@@ -299,7 +305,7 @@ def test_gui_upload_task_missing_circle_multiple(mw, qtbot):
          mock.patch.object(QtWidgets.QInputDialog, "getItem",
                            return_value=(common.CIRCLE, True)), \
          mock.patch.object(QMessageBox, "information", return_value=None):
-        act = QtWidgets.QAction("some unimportant text")
+        act = QtGui.QAction("some unimportant text")
         act.setData("bulk")
         request_circle = widget_upload.circle_mgr.request_circle
         with mock.patch.object(widget_upload.circle_mgr,
@@ -323,7 +329,7 @@ def test_gui_upload_private(mw, qtbot):
     dlg.comboBox_vis.setCurrentIndex(dlg.comboBox_vis.findData("private"))
     # Avoid message boxes
     with mock.patch.object(QMessageBox, "question",
-                           return_value=QMessageBox.Yes), \
+                           return_value=QMessageBox.StandardButton.Yes), \
          mock.patch.object(QMessageBox, "information", return_value=None):
         # Commence upload
         dlg.on_proceed()
@@ -347,14 +353,15 @@ def test_gui_upload_task_missing_circle(mw, qtbot):
     dataset_dict.pop("owner_org")
     tpath = common.make_upload_task(task_id=task_id,
                                     dataset_dict=dataset_dict)
-    QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 300)
+    QtWidgets.QApplication.processEvents(
+        QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 300)
     with mock.patch.object(
             QtWidgets.QFileDialog, "getOpenFileNames",
             return_value=([tpath], None)), \
          mock.patch.object(QtWidgets.QInputDialog, "getItem",
                            return_value=(common.CIRCLE, True)), \
          mock.patch.object(QMessageBox, "information", return_value=None):
-        act = QtWidgets.QAction("some unimportant text")
+        act = QtGui.QAction("some unimportant text")
         act.setData("single")
         mw.panel_upload.on_upload_task(action=act)
     uj = mw.panel_upload.jobs[-1]


### PR DESCRIPTION
<!-- brief intro. What does this merge request aim to do and why -->
## Intro
This PR aims to migrate the codebase from PyQt5 to PyQt6
This is necessary because Qt Creator does not support PyQt5. It is explained in issue #[165](https://github.com/ZELLMECHANIK-DRESDEN/ShapeOut2/issues/165).

<!-- Step by step guide, this helps! -->
### To do:
- [x] Refactor code to be adopted to PyQt6
- [ ] CI/CD pipeline passed
- [ ] update CHANGELOG