### PR TITLE
fix: update Qt.LeftButton usage for PyQt6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.17.3
+ - fix: update Qt.LeftButton usage for PyQt6 (#88)
  - enh: allow specifying collections in upload task files and via the API
  - docs: increase warning threshold for max number of resources to 1000
    (CKAN 2.11.3 handles datasets with many resources much better)

--- a/dcoraid/gui/dbview/drag_table_widget.py
+++ b/dcoraid/gui/dbview/drag_table_widget.py
@@ -4,7 +4,7 @@ from PyQt6.QtCore import Qt
 
 class DragTableWidget(QtWidgets.QTableWidget):
     def mouseMoveEvent(self, e):
-        if e.buttons() != Qt.LeftButton:
+        if e.buttons() != Qt.MouseButton.LeftButton:
             return
 
         urls = []


### PR DESCRIPTION
This PR aims to fix issue #88 