### PR TITLE
fix: upadte Qt.CopyAction usage for PyQt6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.17.3
+ - fix: upadte Qt.CopyAction usage for PyQt6 (#88)
  - fix: update Qt.LeftButton usage for PyQt6 (#88)
  - enh: allow specifying collections in upload task files and via the API
  - docs: increase warning threshold for max number of resources to 1000

--- a/dcoraid/gui/dbview/drag_table_widget.py
+++ b/dcoraid/gui/dbview/drag_table_widget.py
@@ -20,4 +20,4 @@ class DragTableWidget(QtWidgets.QTableWidget):
         drag.setHotSpot(e.pos() - self.rect().topLeft())
 
         # This magic is somehow required to get drag working.
-        dropAction = drag.exec(Qt.CopyAction)  # noqa: F841
+        dropAction = drag.exec(Qt.DropAction.CopyAction)  # noqa: F841


### PR DESCRIPTION
This PR aims to fix the bug mentioned in #88

https://github.com/DCOR-dev/DCOR-Aid/issues/88#issuecomment-3140787602
