### PR TITLE
fix: on_wizard method should be _init

### DIFF
--- a/dcoraid/gui/main.py
+++ b/dcoraid/gui/main.py
@@ -134,7 +134,7 @@ class DCORAid(QtWidgets.QMainWindow):
         if ((self.settings.value("user scenario", "") != "anonymous")
                 and not self.settings.value("auth/api key", "")):
             # User has not done anything yet
-            self.on_wizard()
+            self.on_wizard_init()
 
         # check for updates
         do_update = int(self.settings.value("check for updates", "1"))


### PR DESCRIPTION
As in the title. When I install 1.1.0 I get the error 

```
Unhandled exception in DCOR-Aid version 1.1.0:
Traceback (most recent call last):
  File "DCOR-AidLauncher.py", line 4, in <module>
  File "dcoraid\__main__.py", line 50, in main
    window = DCORAid()
  File "dcoraid\gui\main.py", line 137, in __init__
    self.on_wizard()
AttributeError: 'DCORAid' object has no attribute 'on_wizard'
```